### PR TITLE
Changed SummonerId from long? to string in LobbyEvent class.

### DIFF
--- a/RiotNet.Tests/Apis/TournamentTests.cs
+++ b/RiotNet.Tests/Apis/TournamentTests.cs
@@ -224,7 +224,7 @@ namespace RiotNet.Tests
             LobbyEvent @event = events.First();
             Assert.That(@event.EventType, Is.Not.Null.And.Not.Empty);
             Assert.That(@event.SummonerId, Is.Not.Null);
-            Assert.That(@event.SummonerId.Value, Is.GreaterThan(0));
+            Assert.That(@event.SummonerId, Is.Not.Null.And.Not.Empty);
             Assert.That(@event.Timestamp, Is.Not.EqualTo(default(DateTime)));
         }
 

--- a/RiotNet/Models/LobbyEvent.cs
+++ b/RiotNet/Models/LobbyEvent.cs
@@ -18,7 +18,7 @@ namespace RiotNet.Models
         /// <summary>
         /// Gets or sets the ID of the summoner who triggered the event, if any.
         /// </summary>
-        public long? SummonerId { get; set; }
+        public string SummonerId { get; set; }
         
         /// <summary>
         /// Gets or sets time at which the event occurred.


### PR DESCRIPTION
As per Riot documentation I've changed SummonerId from long? to string.
Updated Tests to reflect this.
https://developer.riotgames.com/api-methods/#tournament-stub-v4/GET_getLobbyEventsByCode